### PR TITLE
Change output mime type to text/plain where appropriate. Only really make

### DIFF
--- a/index.html
+++ b/index.html
@@ -718,7 +718,7 @@
 <pre class="prettyprint lang-js">var http = require("http");
 
 http.createServer(function(request, response) {
-  response.writeHead(200, {"Content-Type": "text/html"});
+  response.writeHead(200, {"Content-Type": "text/plain"});
   response.write("Hello World");
   response.end();
 }).listen(8888);
@@ -856,7 +856,7 @@ execute(function(word){ console.log(word) }, "Hello");
 <pre class="prettyprint lang-js">var http = require("http");
 
 http.createServer(function(request, response) {
-  response.writeHead(200, {"Content-Type": "text/html"});
+  response.writeHead(200, {"Content-Type": "text/plain"});
   response.write("Hello World");
   response.end();
 }).listen(8888);
@@ -872,7 +872,7 @@ http.createServer(function(request, response) {
 <pre class="prettyprint lang-js">var http = require("http");
 
 function onRequest(request, response) {
-  response.writeHead(200, {"Content-Type": "text/html"});
+  response.writeHead(200, {"Content-Type": "text/plain"});
   response.write("Hello World");
   response.end();
 }
@@ -962,7 +962,7 @@ http.createServer(onRequest).listen(8888);
 
 function onRequest(request, response) {
   console.log("Request received.");
-  response.writeHead(200, {"Content-Type": "text/html"});
+  response.writeHead(200, {"Content-Type": "text/plain"});
   response.write("Hello World");
   response.end();
 }
@@ -1105,7 +1105,7 @@ foo.createServer(...);
 function start() {
   function onRequest(request, response) {
     console.log("Request received.");
-    response.writeHead(200, {"Content-Type": "text/html"});
+    response.writeHead(200, {"Content-Type": "text/plain"});
     response.write("Hello World");
     response.end();
   }
@@ -1220,7 +1220,7 @@ function start() {
   function onRequest(request, response) {
 	var pathname = url.parse(request.url).pathname;
 	console.log("Request for " + pathname + " received.");
-	response.writeHead(200, {"Content-Type": "text/html"});
+	response.writeHead(200, {"Content-Type": "text/plain"});
 	response.write("Hello World");
 	response.end();
   }
@@ -1282,7 +1282,7 @@ function start(route) {
 
     route(pathname);
 
-    response.writeHead(200, {"Content-Type": "text/html"});
+    response.writeHead(200, {"Content-Type": "text/plain"});
     response.write("Hello World");
     response.end();
   }
@@ -1507,7 +1507,7 @@ function start(route, handle) {
 
     route(handle, pathname);
 
-    response.writeHead(200, {"Content-Type": "text/html"});
+    response.writeHead(200, {"Content-Type": "text/plain"});
     response.write("Hello World");
     response.end();
   }
@@ -1657,7 +1657,7 @@ function start(route, handle) {
     var pathname = url.parse(request.url).pathname;
     console.log("Request for " + pathname + " received.");
 
-    response.writeHead(200, {"Content-Type": "text/html"});
+    response.writeHead(200, {"Content-Type": "text/plain"});
 	var content = route(handle, pathname)
 	response.write(content);
     response.end();
@@ -1990,7 +1990,7 @@ exports.start = start;
     handle[pathname](response);
   } else {
     console.log("No request handler found for " + pathname);
-    response.writeHead(404, {"Content-Type": "text/html"});
+    response.writeHead(404, {"Content-Type": "text/plain"});
     response.write("404 Not found");
     response.end();
   }
@@ -2015,7 +2015,7 @@ function start(response) {
   console.log("Request handler 'start' was called.");
 
   exec("ls -lah", function (error, stdout, stderr) {
-    response.writeHead(200, {"Content-Type": "text/html"});
+    response.writeHead(200, {"Content-Type": "text/plain"});
     response.write(stdout);
     response.end();
   });
@@ -2023,7 +2023,7 @@ function start(response) {
 
 function upload(response) {
   console.log("Request handler 'upload' was called.");
-  response.writeHead(200, {"Content-Type": "text/html"});
+  response.writeHead(200, {"Content-Type": "text/plain"});
   response.write("Hello Upload");
   response.end();
 }
@@ -2060,7 +2060,7 @@ function start(response) {
   exec("find /",
     { timeout: 10000, maxBuffer: 20000*1024 },
     function (error, stdout, stderr) {
-      response.writeHead(200, {"Content-Type": "text/html"});
+      response.writeHead(200, {"Content-Type": "text/plain"});
       response.write(stdout);
       response.end();
     });
@@ -2068,7 +2068,7 @@ function start(response) {
 
 function upload(response) {
   console.log("Request handler 'upload' was called.");
-  response.writeHead(200, {"Content-Type": "text/html"});
+  response.writeHead(200, {"Content-Type": "text/plain"});
   response.write("Hello Upload");
   response.end();
 }
@@ -2157,7 +2157,7 @@ exports.upload = upload;
 
 function upload(response) {
   console.log("Request handler 'upload' was called.");
-  response.writeHead(200, {"Content-Type": "text/html"});
+  response.writeHead(200, {"Content-Type": "text/plain"});
   response.write("Hello Upload");
   response.end();
 }
@@ -2308,7 +2308,7 @@ exports.start = start;
     handle[pathname](response, postData);
   } else {
     console.log("No request handler found for " + pathname);
-    response.writeHead(404, {"Content-Type": "text/html"});
+    response.writeHead(404, {"Content-Type": "text/plain"});
     response.write("404 Not found");
     response.end();
   }
@@ -2342,7 +2342,7 @@ exports.route = route;
 
 function upload(response, postData) {
   console.log("Request handler 'upload' was called.");
-  response.writeHead(200, {"Content-Type": "text/html"});
+  response.writeHead(200, {"Content-Type": "text/plain"});
   response.write("You've sent: " + postData);
   response.end();
 }
@@ -2390,7 +2390,7 @@ function start(response, postData) {
 
 function upload(response, postData) {
   console.log("Request handler 'upload' was called.");
-  response.writeHead(200, {"Content-Type": "text/html"});
+  response.writeHead(200, {"Content-Type": "text/plain"});
   response.write("You've sent the text: " + querystring.parse(postData)["text"]);
   response.end();
 }


### PR DESCRIPTION
Hi there,

Loving the book, it's been an absolute blessing. I was swimming around in a million tutorials that went no further than hello world when I found it.

This is the first time I've tried doing a fork and sending a pull request on github, so hopefully I've done this correctly.

I'm suggesting only a small change to the mime type in several places to text/plain. What made me think to do this was the echo'd output of the command ls -la. When outout as text/html the line breaks are obviously ignored by the browser, so text/plain gives a tidier result.

I haven't changed the examples that actually do output html, and haven't edited any other text to explain where the difference lies, but I know that some people reading this probably wont have vast experience with thinking about mime type, they'll probably have had that dealt with on auto-pilot by apache and perhaps this small change might help prevent them picking up an accidental bad habit on the way through.
