### PR TITLE
Added a fs.unlinkSync call to the requestHandler.js file - on Windows if...

### DIFF
--- a/code/application/requestHandlers.js
+++ b/code/application/requestHandlers.js
@@ -31,6 +31,12 @@ function upload(response, request) {
   console.log("about to parse");
   form.parse(request, function(error, fields, files) {
     console.log("parsing done");
+    
+    /*
+     * Some systems [Windows] raise an error when you attempt to rename new file into one that already exists.
+     * This call deletes the previous .PNG image prior to renaming the new one in its place.
+    */
+    fs.unlinkSync("/tmp/test.png"); .
     fs.renameSync(files.upload.path, "/tmp/test.png");
     response.writeHead(200, {"Content-Type": "text/html"});
     response.write("received image:<br/>");


### PR DESCRIPTION
... you try to rename a new file onto one that already exists the file system spits an error back at you. This approach removes the file before the rename is ever attempted.
