### PR TITLE
Updated Node installation path. closes #65

### DIFF
--- a/index-en.html
+++ b/index-en.html
@@ -438,7 +438,7 @@
             In order to make use of these, you need to install Node.js.
             Instead of repeating the process here, I kindly ask you to
             visit
-            <a href="https://github.com/joyent/node/wiki/Installation" title="Building and Installing Node.js">the
+            <a href="https://nodejs.org/en/download/" title="Building and Installing Node.js">the
                 official
                 installation instructions</a>. Please come back once you
             are up and running.


### PR DESCRIPTION
Updated the link to Node installation. The one on Node's Github account has moved to official website. This fix closes issue #65